### PR TITLE
correct the fix

### DIFF
--- a/MPU6050.h
+++ b/MPU6050.h
@@ -41,9 +41,8 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <time.h>
-extern "C"{ //include the c library in cpp programs.
-	#include <linux/i2c-dev.h>
-}
+#include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 #include <cmath>
 #include <thread>
 


### PR DESCRIPTION
Sorry for the last report. I later found out that the error was caused by a header file not included instead of the c code identifier.  We should just `#include <i2c/smbus.h>` then.