### PR TITLE
Voluntary thread

### DIFF
--- a/Example.cpp
+++ b/Example.cpp
@@ -6,7 +6,7 @@
 
 #include <MPU6050.h>
 
-MPU6050 device(0x68);
+MPU6050 device(0x68, true);
 
 int main() {
 	float ax, ay, az, gr, gp, gy; //Variables to store the accel, gyro and angle values

--- a/Example.cpp
+++ b/Example.cpp
@@ -6,7 +6,7 @@
 
 #include <MPU6050.h>
 
-MPU6050 device(0x68, true);
+MPU6050 device(0x68);
 
 int main() {
 	float ax, ay, az, gr, gp, gy; //Variables to store the accel, gyro and angle values

--- a/MPU6050.cpp
+++ b/MPU6050.cpp
@@ -41,6 +41,8 @@ MPU6050::MPU6050(int8_t addr, bool run_update_thread) {
 	}
 }
 
+MPU6050::MPU6050(int8_t addr) : MPU6050(addr, true){}
+
 void MPU6050::getGyroRaw(float *roll, float *pitch, float *yaw) {
 	int16_t X = i2c_smbus_read_byte_data(f_dev, 0x43) << 8 | i2c_smbus_read_byte_data(f_dev, 0x44); //Read X registers
 	int16_t Y = i2c_smbus_read_byte_data(f_dev, 0x45) << 8 | i2c_smbus_read_byte_data(f_dev, 0x46); //Read Y registers

--- a/MPU6050.cpp
+++ b/MPU6050.cpp
@@ -5,7 +5,7 @@
 //Include the header file for this class
 #include "MPU6050.h"
 
-MPU6050::MPU6050(int8_t addr) {
+MPU6050::MPU6050(int8_t addr, bool run_update_thread) {
 	int status;
 
 	MPU6050_addr = addr;
@@ -36,7 +36,9 @@ MPU6050::MPU6050(int8_t addr) {
 	//Set offsets to zero
 	i2c_smbus_write_byte_data(f_dev, 0x06, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x07, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x08, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x09, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x0A, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x0B, 0b00000000), i2c_smbus_write_byte_data(f_dev, 0x00, 0b10000001), i2c_smbus_write_byte_data(f_dev, 0x01, 0b00000001), i2c_smbus_write_byte_data(f_dev, 0x02, 0b10000001);
 
-	std::thread(&MPU6050::_update, this).detach(); //Create a seperate thread, for the update routine to run in the background, and detach it, allowing the program to continue
+	if (run_update_thread){
+		std::thread(&MPU6050::_update, this).detach(); //Create a seperate thread, for the update routine to run in the background, and detach it, allowing the program to continue
+	}
 }
 
 void MPU6050::getGyroRaw(float *roll, float *pitch, float *yaw) {

--- a/MPU6050.h
+++ b/MPU6050.h
@@ -107,6 +107,7 @@ class MPU6050 {
 
 		bool _first_run = 1; //Variable for whether to set gyro angle to acceleration angle in compFilter
 	public:
+		MPU6050(int8_t addr);
 		MPU6050(int8_t addr, bool run_update_thread);
 		void getAccelRaw(float *x, float *y, float *z);
 		void getGyroRaw(float *roll, float *pitch, float *yaw);

--- a/MPU6050.h
+++ b/MPU6050.h
@@ -107,7 +107,7 @@ class MPU6050 {
 
 		bool _first_run = 1; //Variable for whether to set gyro angle to acceleration angle in compFilter
 	public:
-		MPU6050(int8_t addr);
+		MPU6050(int8_t addr, bool run_update_thread);
 		void getAccelRaw(float *x, float *y, float *z);
 		void getGyroRaw(float *roll, float *pitch, float *yaw);
 		void getAccel(float *x, float *y, float *z);


### PR DESCRIPTION
In some situations one might want to run a custom `update` routine, so it would be good to have the option to not run the thread which runs the `update` method. I have added a new constructor with that option, and kept the existing one as it was, defaulting to true.